### PR TITLE
Add govet-fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,8 @@ linters-settings:
     min-confidence: 0.9
   govet:
     check-shadowing: true
+    enable:
+    - "fieldalignment"
   gocyclo:
     min-complexity: 15
   gocognit:

--- a/cmd/fpga_crihook/main.go
+++ b/cmd/fpga_crihook/main.go
@@ -60,9 +60,8 @@ type newPortFun func(string) (fpga.Port, error)
 
 // Device defines structure for Config.Linux.Devices entries.
 type Device struct {
-	// these fields are set by the hook
-	name      string
-	processed bool
+	// this field is set by the hook
+	name string
 
 	// these are set by JSON decoder
 	Path  string `json:"path"`
@@ -71,6 +70,9 @@ type Device struct {
 	Minor int    `json:"minor"`
 	UID   int    `json:"uid"`
 	GID   int    `json:"gid"`
+
+	// this field is set by the hook
+	processed bool
 }
 
 func (dev *Device) getName() string {
@@ -87,9 +89,9 @@ func decodeJSONStream(reader io.Reader, dest interface{}) error {
 }
 
 type hookEnv struct {
+	newPort      newPortFun
 	bitstreamDir string
 	config       string
-	newPort      newPortFun
 }
 
 type fpgaParams struct {

--- a/cmd/fpga_crihook/main_test.go
+++ b/cmd/fpga_crihook/main_test.go
@@ -179,9 +179,9 @@ func TestGetConfig(t *testing.T) {
 // testFpgaPort represent Fake FPGA Port device for testing purposes.
 type testFpgaPort struct {
 	fpga.Port
-	callNo          int
 	interfaceUUIDS  []string
 	accelTypeUUIDS  []string
+	callNo          int
 	failProgramming bool
 }
 
@@ -229,12 +229,12 @@ func TestGetFPGAParams(t *testing.T) {
 		stdinJSON          string
 		configJSON         string
 		afuIDPath          string
-		sysfsdirs          []string
-		sysfsfiles         map[string][]byte
-		expectedErr        bool
 		expectedRegion     string
 		expectedAFU        string
 		expectedPortDevice string
+		sysfsfiles         map[string][]byte
+		sysfsdirs          []string
+		expectedErr        bool
 	}{
 		{
 			name:       "valid setup",
@@ -343,9 +343,9 @@ func TestProcess(t *testing.T) {
 		name        string
 		stdinJSON   string
 		configJSON  string
-		sysfsdirs   []string
-		sysfsfiles  map[string][]byte
 		newPort     newPortFun
+		sysfsfiles  map[string][]byte
+		sysfsdirs   []string
 		expectedErr bool
 	}{
 		{

--- a/cmd/fpga_plugin/dfl_test.go
+++ b/cmd/fpga_plugin/dfl_test.go
@@ -315,13 +315,13 @@ func TestScanFPGAsDFL(t *testing.T) {
 	sysfs := path.Join(tmpdir, "sys")
 	dev := path.Join(tmpdir, "dev")
 	tcases := []struct {
-		name                string
-		mode                string
-		devs                []string
 		sysfsdirs           []string
 		sysfsfiles          map[string][]byte
 		newPort             newPortFunc
 		expectedDevTreeKeys map[string][]string
+		name                string
+		mode                string
+		devs                []string
 	}{
 		{
 			name: "Valid DFL scan in af mode",

--- a/cmd/fpga_plugin/fpga_plugin.go
+++ b/cmd/fpga_plugin/fpga_plugin.go
@@ -174,10 +174,10 @@ type devicePlugin struct {
 	getDevTree getDevTreeFunc
 	newPort    newPortFunc
 
-	annotationValue string
-
 	scanTicker *time.Ticker
 	scanDone   chan bool
+
+	annotationValue string
 }
 
 // newDevicePlugin returns new instance of devicePlugin.

--- a/cmd/fpga_plugin/fpga_plugin_test.go
+++ b/cmd/fpga_plugin/fpga_plugin_test.go
@@ -191,12 +191,12 @@ func TestScan(t *testing.T) {
 	dev := path.Join(root, "dev")
 
 	tcases := []struct {
-		name       string
-		mode       string
-		devs       []string
 		sysfsdirs  []string
 		sysfsfiles map[string][]byte
 		newPort    newPortFunc
+		name       string
+		mode       string
+		devs       []string
 	}{
 		{
 			name: "valid OPAE scan in af mode",

--- a/cmd/fpga_plugin/opae_test.go
+++ b/cmd/fpga_plugin/opae_test.go
@@ -267,13 +267,13 @@ func TestScanFPGAsOPAE(t *testing.T) {
 	sysfs := path.Join(tmpdir, "sys")
 	dev := path.Join(tmpdir, "dev")
 	tcases := []struct {
-		name                string
-		mode                string
-		devs                []string
 		sysfsdirs           []string
 		sysfsfiles          map[string][]byte
 		newPort             newPortFunc
 		expectedDevTreeKeys map[string][]string
+		name                string
+		mode                string
+		devs                []string
 	}{
 		{
 			name: "Valid OPAE scan in af mode",

--- a/cmd/gpu_nfdhook/labeler.go
+++ b/cmd/gpu_nfdhook/labeler.go
@@ -44,12 +44,12 @@ const (
 type labelMap map[string]string
 
 type labeler struct {
-	sysfsDRMDir   string
-	debugfsDRIDir string
-
 	gpuDeviceReg     *regexp.Regexp
 	controlDeviceReg *regexp.Regexp
 	labels           labelMap
+
+	sysfsDRMDir   string
+	debugfsDRIDir string
 }
 
 func newLabeler(sysfsDRMDir, debugfsDRIDir string) *labeler {

--- a/cmd/gpu_nfdhook/labeler_test.go
+++ b/cmd/gpu_nfdhook/labeler_test.go
@@ -23,14 +23,14 @@ import (
 )
 
 type testcase struct {
-	sysfsdirs      []string
-	sysfsfiles     map[string][]byte
-	name           string
-	memoryOverride uint64
-	memoryReserved uint64
 	capabilityFile map[string][]byte
 	expectedRetval error
 	expectedLabels labelMap
+	name           string
+	sysfsfiles     map[string][]byte
+	sysfsdirs      []string
+	memoryOverride uint64
+	memoryReserved uint64
 }
 
 //nolint:funlen

--- a/cmd/gpu_plugin/gpu_plugin.go
+++ b/cmd/gpu_plugin/gpu_plugin.go
@@ -59,11 +59,6 @@ type cliOptions struct {
 }
 
 type devicePlugin struct {
-	sysfsDir string
-	devfsDir string
-
-	options cliOptions
-
 	gpuDeviceReg     *regexp.Regexp
 	controlDeviceReg *regexp.Regexp
 
@@ -71,6 +66,11 @@ type devicePlugin struct {
 	scanDone   chan bool
 
 	resMan rm.ResourceManager
+
+	sysfsDir string
+	devfsDir string
+
+	options cliOptions
 }
 
 func newDevicePlugin(sysfsDir, devfsDir string, options cliOptions) *devicePlugin {

--- a/cmd/gpu_plugin/gpu_plugin_test.go
+++ b/cmd/gpu_plugin/gpu_plugin_test.go
@@ -102,9 +102,9 @@ func TestScan(t *testing.T) {
 	tcases := []struct {
 		name string
 		// test-case environment
-		devfsdirs  []string
 		sysfsdirs  []string
 		sysfsfiles map[string][]byte
+		devfsdirs  []string
 		// how plugin should interpret it
 		options cliOptions
 		// what the result should be

--- a/cmd/gpu_plugin/rm/gpu_plugin_resource_manager.go
+++ b/cmd/gpu_plugin/rm/gpu_plugin_resource_manager.go
@@ -66,9 +66,9 @@ type podCandidate struct {
 }
 
 type DeviceInfo struct {
+	envs   map[string]string
 	nodes  []pluginapi.DeviceSpec
 	mounts []pluginapi.Mount
-	envs   map[string]string
 }
 
 type getClientFunc func(string, time.Duration, int) (podresourcesv1.PodResourcesListerClient, *grpc.ClientConn, error)
@@ -80,13 +80,13 @@ type ResourceManager interface {
 }
 
 type resourceManager struct {
-	mutex            sync.RWMutex // for devTree updates during scan
 	deviceInfos      DeviceInfoMap
 	nodeName         string
 	clientset        kubernetes.Interface
+	prGetClientFunc  getClientFunc
 	skipID           string
 	fullResourceName string
-	prGetClientFunc  getClientFunc
+	mutex            sync.RWMutex // for devTree updates during scan
 }
 
 // NewDeviceInfo creates a new DeviceInfo.

--- a/cmd/gpu_plugin/rm/gpu_plugin_resource_manager_test.go
+++ b/cmd/gpu_plugin/rm/gpu_plugin_resource_manager_test.go
@@ -160,8 +160,8 @@ func TestReallocateWithFractionalResources(t *testing.T) {
 	testCases := []struct {
 		name              string
 		pods              []v1.Pod
-		expectErr         bool
 		containerRequests []*v1beta1.ContainerAllocateRequest
+		expectErr         bool
 	}{
 		{
 			name:              "Wrong number of container requests should fail",

--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv.go
@@ -63,11 +63,11 @@ var qatDeviceDriver = map[string]string{
 
 // DevicePlugin represents vfio based QAT plugin.
 type DevicePlugin struct {
-	maxDevices      int
 	pciDriverDir    string
 	pciDeviceDir    string
-	kernelVfDrivers []string
 	dpdkDriver      string
+	kernelVfDrivers []string
+	maxDevices      int
 }
 
 // NewDevicePlugin returns new instance of vfio based QAT plugin.

--- a/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
+++ b/cmd/qat_plugin/dpdkdrv/dpdkdrv_test.go
@@ -109,10 +109,10 @@ func TestScanPrivate(t *testing.T) {
 	tcases := []struct {
 		name            string
 		dpdkDriver      string
-		kernelVfDrivers []string
 		dirs            []string
 		files           map[string][]byte
 		symlinks        map[string]string
+		kernelVfDrivers []string
 		expectedErr     bool
 		maxDevNum       int
 		expectedDevNum  int

--- a/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
+++ b/cmd/qat_plugin/kerneldrv/kerneldrv_test.go
@@ -68,8 +68,8 @@ func init() {
 func TestGetOnlineDevices(t *testing.T) {
 	tcases := []struct {
 		name           string
-		adfCtlOutput   string
 		adfCtlError    error
+		adfCtlOutput   string
 		expectedDevNum int
 		expectedErr    bool
 		iommuOn        bool
@@ -136,8 +136,8 @@ func TestGetUIODevices(t *testing.T) {
 		name        string
 		devType     string
 		bsf         string
-		expectedErr bool
 		uiodevs     []string
+		expectedErr bool
 	}{
 		{
 			name:        "can't read sysfs",
@@ -243,9 +243,9 @@ func TestGetDevTree(t *testing.T) {
 	tcases := []struct {
 		name        string
 		sysfs       string
+		config      map[string]section
 		uiodevs     map[string][]string
 		qatdevs     []device
-		config      map[string]section
 		expectedErr bool
 	}{
 		{

--- a/cmd/sgx_epchook/main.go
+++ b/cmd/sgx_epchook/main.go
@@ -38,9 +38,9 @@ const (
 )
 
 type patchNodeOp struct {
+	Value interface{} `json:"value"`
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
-	Value interface{} `json:"value"`
 }
 
 func main() {

--- a/cmd/sgx_plugin/sgx_plugin.go
+++ b/cmd/sgx_plugin/sgx_plugin.go
@@ -38,10 +38,10 @@ const (
 )
 
 type devicePlugin struct {
+	scanDone   chan bool
 	devfsDir   string
 	nEnclave   uint
 	nProvision uint
-	scanDone   chan bool
 }
 
 func newDevicePlugin(devfsDir string, nEnclave, nProvision uint) *devicePlugin {

--- a/cmd/vpu_plugin/vpu_plugin.go
+++ b/cmd/vpu_plugin/vpu_plugin.go
@@ -61,7 +61,7 @@ var (
 	// Movidius MyriadX Product IDs.
 	productIDs = []int{0x2485, 0xf63b}
 	// PCI Product IDs.
-	productIDsPCI = []PCIPidDeviceType{{[]string{"0x6240"}, "kmb", 1}}
+	productIDsPCI = []PCIPidDeviceType{{"kmb", []string{"0x6240"}, 1}}
 )
 
 type gousbContext interface {
@@ -69,8 +69,8 @@ type gousbContext interface {
 }
 
 type PCIPidDeviceType struct {
-	pids       []string
 	deviceType string
+	pids       []string
 	ratio      int
 }
 
@@ -100,15 +100,15 @@ func getPciDeviceCounts(sysfsPciDevicesPath string, vendorID string, pidSearch [
 
 type devicePlugin struct {
 	deviceCtx    interface{}
-	sharedDevNum int
 	scanTicker   *time.Ticker
 	scanDone     chan bool
+	sharedDevNum int
 }
 
 type devicePluginUsb struct {
 	usbContext gousbContext
-	vendorID   int
 	productIDs []int
+	vendorID   int
 }
 
 type devicePluginPci struct {

--- a/cmd/vpu_plugin/vpu_plugin_test.go
+++ b/cmd/vpu_plugin/vpu_plugin_test.go
@@ -31,8 +31,8 @@ func init() {
 }
 
 type testCase struct {
-	vendorID   int
 	productIDs []int
+	vendorID   int
 }
 
 //OpenDevices tries to inject gousb compatible fake device info.

--- a/pkg/apis/deviceplugin/v1/dsadeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/dsadeviceplugin_types.go
@@ -25,6 +25,9 @@ import (
 type DsaDevicePluginSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
+	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Image is a container image with DSA device plugin executable.
 	Image string `json:"image,omitempty"`
 
@@ -35,9 +38,6 @@ type DsaDevicePluginSpec struct {
 	// LogLevel sets the plugin's log level.
 	// +kubebuilder:validation:Minimum=0
 	LogLevel int `json:"logLevel,omitempty"`
-
-	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // DsaDevicePluginStatus defines the observed state of DsaDevicePlugin.
@@ -49,6 +49,10 @@ type DsaDevicePluginStatus struct {
 	// +optional
 	ControlledDaemonSet v1.ObjectReference `json:"controlledDaemonSet,omitempty"`
 
+	// The list of Node names where the device plugin pods are running.
+	// +optional
+	NodeNames []string `json:"nodeNames,omitempty"`
+
 	// The total number of nodes that should be running the device plugin
 	// pod (including nodes correctly running the device plugin pod).
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
@@ -56,10 +60,6 @@ type DsaDevicePluginStatus struct {
 	// The number of nodes that should be running the device plugin pod and have one
 	// or more of the device plugin pod running and ready.
 	NumberReady int32 `json:"numberReady"`
-
-	// The list of Node names where the device plugin pods are running.
-	// +optional
-	NodeNames []string `json:"nodeNames,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/deviceplugin/v1/fpgadeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/fpgadeviceplugin_types.go
@@ -25,6 +25,9 @@ import (
 type FpgaDevicePluginSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
+	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Image is a container image with FPGA device plugin executable.
 	Image string `json:"image,omitempty"`
 
@@ -38,9 +41,6 @@ type FpgaDevicePluginSpec struct {
 	// LogLevel sets the plugin's log level.
 	// +kubebuilder:validation:Minimum=0
 	LogLevel int `json:"logLevel,omitempty"`
-
-	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // FpgaDevicePluginStatus defines the observed state of FpgaDevicePlugin.
@@ -52,6 +52,10 @@ type FpgaDevicePluginStatus struct {
 	// +optional
 	ControlledDaemonSet v1.ObjectReference `json:"controlledDaemonSet,omitempty"`
 
+	// The list of Node names where the device plugin pods are running.
+	// +optional
+	NodeNames []string `json:"nodeNames,omitempty"`
+
 	// The total number of nodes that should be running the device plugin
 	// pod (including nodes correctly running the device plugin pod).
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
@@ -59,10 +63,6 @@ type FpgaDevicePluginStatus struct {
 	// The number of nodes that should be running the device plugin pod and have one
 	// or more of the device plugin pod running and ready.
 	NumberReady int32 `json:"numberReady"`
-
-	// The list of Node names where the device plugin pods are running.
-	// +optional
-	NodeNames []string `json:"nodeNames,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/gpudeviceplugin_types.go
@@ -25,6 +25,9 @@ import (
 type GpuDevicePluginSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
+	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Image is a container image with GPU device plugin executable.
 	Image string `json:"image,omitempty"`
 
@@ -45,9 +48,6 @@ type GpuDevicePluginSpec struct {
 	// EnableMonitoring enables the monitoring resource ('i915_monitoring')
 	// which gives access to all GPU devices on given node.
 	EnableMonitoring bool `json:"enableMonitoring,omitempty"`
-
-	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // GpuDevicePluginStatus defines the observed state of GpuDevicePlugin.
@@ -60,6 +60,10 @@ type GpuDevicePluginStatus struct {
 	// +optional
 	ControlledDaemonSet v1.ObjectReference `json:"controlledDaemonSet,omitempty"`
 
+	// The list of Node names where the device plugin pods are running.
+	// +optional
+	NodeNames []string `json:"nodeNames,omitempty"`
+
 	// The total number of nodes that should be running the device plugin
 	// pod (including nodes correctly running the device plugin pod).
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
@@ -67,10 +71,6 @@ type GpuDevicePluginStatus struct {
 	// The number of nodes that should be running the device plugin pod and have one
 	// or more of the device plugin pod running and ready.
 	NumberReady int32 `json:"numberReady"`
-
-	// The list of Node names where the device plugin pods are running.
-	// +optional
-	NodeNames []string `json:"nodeNames,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -89,8 +89,8 @@ type GpuDevicePlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   GpuDevicePluginSpec   `json:"spec,omitempty"`
 	Status GpuDevicePluginStatus `json:"status,omitempty"`
+	Spec   GpuDevicePluginSpec   `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/deviceplugin/v1/qatdeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/qatdeviceplugin_types.go
@@ -37,6 +37,9 @@ type QatDevicePluginSpec struct {
 	// +kubebuilder:validation:Enum=igb_uio;vfio-pci
 	DpdkDriver string `json:"dpdkDriver,omitempty"`
 
+	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// KernelVfDrivers is a list of VF device drivers for the QuickAssist devices in the system.
 	KernelVfDrivers []KernelVfDriver `json:"kernelVfDrivers,omitempty"`
 
@@ -47,9 +50,6 @@ type QatDevicePluginSpec struct {
 	// LogLevel sets the plugin's log level.
 	// +kubebuilder:validation:Minimum=0
 	LogLevel int `json:"logLevel,omitempty"`
-
-	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // QatDevicePluginStatus defines the observed state of QatDevicePlugin.
@@ -62,6 +62,10 @@ type QatDevicePluginStatus struct {
 	// +optional
 	ControlledDaemonSet v1.ObjectReference `json:"controlledDaemonSet,omitempty"`
 
+	// The list of Node names where the device plugin pods are running.
+	// +optional
+	NodeNames []string `json:"nodeNames,omitempty"`
+
 	// The total number of nodes that should be running the device plugin
 	// pod (including nodes correctly running the device plugin pod).
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
@@ -69,10 +73,6 @@ type QatDevicePluginStatus struct {
 	// The number of nodes that should be running the device plugin pod and have one
 	// or more of the device plugin pod running and ready.
 	NumberReady int32 `json:"numberReady"`
-
-	// The list of Node names where the device plugin pods are running.
-	// +optional
-	NodeNames []string `json:"nodeNames,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -91,8 +91,8 @@ type QatDevicePlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   QatDevicePluginSpec   `json:"spec,omitempty"`
 	Status QatDevicePluginStatus `json:"status,omitempty"`
+	Spec   QatDevicePluginSpec   `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/deviceplugin/v1/sgxdeviceplugin_types.go
+++ b/pkg/apis/deviceplugin/v1/sgxdeviceplugin_types.go
@@ -25,6 +25,9 @@ import (
 type SgxDevicePluginSpec struct {
 	// Important: Run "make generate" to regenerate code after modifying this file
 
+	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
 	// Image is a container image with SGX device plugin executable.
 	Image string `json:"image,omitempty"`
 
@@ -42,9 +45,6 @@ type SgxDevicePluginSpec struct {
 	// LogLevel sets the plugin's log level.
 	// +kubebuilder:validation:Minimum=0
 	LogLevel int `json:"logLevel,omitempty"`
-
-	// NodeSelector provides a simple way to constrain device plugin pods to nodes with particular labels.
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // SgxDevicePluginStatus defines the observed state of SgxDevicePlugin.
@@ -56,6 +56,10 @@ type SgxDevicePluginStatus struct {
 	// +optional
 	ControlledDaemonSet v1.ObjectReference `json:"controlledDaemonSet,omitempty"`
 
+	// The list of Node names where the device plugin pods are running.
+	// +optional
+	NodeNames []string `json:"nodeNames,omitempty"`
+
 	// The total number of nodes that should be running the device plugin
 	// pod (including nodes correctly running the device plugin pod).
 	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
@@ -63,10 +67,6 @@ type SgxDevicePluginStatus struct {
 	// The number of nodes that should be running the device plugin pod and have one
 	// or more of the device plugin pod running and ready.
 	NumberReady int32 `json:"numberReady"`
-
-	// The list of Node names where the device plugin pods are running.
-	// +optional
-	NodeNames []string `json:"nodeNames,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -85,8 +85,8 @@ type SgxDevicePlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   SgxDevicePluginSpec   `json:"spec,omitempty"`
 	Status SgxDevicePluginStatus `json:"status,omitempty"`
+	Spec   SgxDevicePluginSpec   `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/fpga/v2/acceleratorfunction_types.go
+++ b/pkg/apis/fpga/v2/acceleratorfunction_types.go
@@ -40,11 +40,11 @@ type AcceleratorFunctionStatus struct{}
 // AcceleratorFunction is a specification for an Accelerator Function resource
 // provided by a FPGA-based programmable hardware accelerator.
 type AcceleratorFunction struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
 	Status AcceleratorFunctionStatus `json:"status,omitempty"`
 	Spec   AcceleratorFunctionSpec   `json:"spec"`
+
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/fpga/v2/fpgaregion_types.go
+++ b/pkg/apis/fpga/v2/fpgaregion_types.go
@@ -34,11 +34,11 @@ type FpgaRegionStatus struct{}
 // FpgaRegion is a specification for a FPGA region resource which can be programmed
 // with a bitstream.
 type FpgaRegion struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-
 	Status FpgaRegionStatus `json:"status,omitempty"`
 	Spec   FpgaRegionSpec   `json:"spec"`
+
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/controllers/reconciler.go
+++ b/pkg/controllers/reconciler.go
@@ -39,6 +39,7 @@ func init() {
 	bKeeper.pluginCounter = make(map[string]int)
 }
 
+//nolint: govet
 type bookKeeper struct {
 	sync.Mutex
 	pluginCounter map[string]int
@@ -99,11 +100,11 @@ type DevicePluginController interface {
 }
 
 type reconciler struct {
+	controller DevicePluginController
 	client.Client
 	scheme     *runtime.Scheme
 	pluginKind string
 	ownerKey   string
-	controller DevicePluginController
 }
 
 // fetchObjects returns the required objects for Reconcile.

--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -23,11 +23,11 @@ import (
 
 // DeviceInfo contains information about device maintained by Device Plugin.
 type DeviceInfo struct {
-	state    string
-	nodes    []pluginapi.DeviceSpec
 	mounts   []pluginapi.Mount
 	envs     map[string]string
 	topology *pluginapi.TopologyInfo
+	state    string
+	nodes    []pluginapi.DeviceSpec
 }
 
 // UseDefaultMethodError allows the plugin to request running the default

--- a/pkg/deviceplugin/manager.go
+++ b/pkg/deviceplugin/manager.go
@@ -76,9 +76,9 @@ func (n *notifier) Notify(newDeviceTree DeviceTree) {
 // received from them.
 type Manager struct {
 	devicePlugin Scanner
-	namespace    string
 	servers      map[string]devicePluginServer
 	createServer func(string, postAllocateFunc, preStartContainerFunc, getPreferredAllocationFunc, allocateFunc) devicePluginServer
+	namespace    string
 }
 
 // NewManager creates a new instance of Manager.

--- a/pkg/deviceplugin/manager_test.go
+++ b/pkg/deviceplugin/manager_test.go
@@ -27,12 +27,12 @@ func init() {
 
 func TestNotify(t *testing.T) {
 	tcases := []struct {
+		oldmap          map[string]map[string]DeviceInfo
+		newmap          map[string]map[string]DeviceInfo
 		name            string
 		expectedAdded   int
 		expectedUpdated int
 		expectedRemoved int
-		oldmap          map[string]map[string]DeviceInfo
-		newmap          map[string]map[string]DeviceInfo
 	}{
 		{
 			name: "No devices found",
@@ -170,9 +170,9 @@ func (*devicePluginStub) GetPreferredAllocation(*pluginapi.PreferredAllocationRe
 
 func TestHandleUpdate(t *testing.T) {
 	tcases := []struct {
-		name            string
 		servers         map[string]devicePluginServer
 		update          updateInfo
+		name            string
 		expectedServers int
 	}{
 		{

--- a/pkg/deviceplugin/server.go
+++ b/pkg/deviceplugin/server.go
@@ -51,7 +51,6 @@ type devicePluginServer interface {
 
 // server implements devicePluginServer and pluginapi.PluginInterfaceServer interfaces.
 type server struct {
-	devType                string
 	grpcServer             *grpc.Server
 	updatesCh              chan map[string]DeviceInfo
 	devices                map[string]DeviceInfo
@@ -59,6 +58,7 @@ type server struct {
 	postAllocate           postAllocateFunc
 	preStartContainer      preStartContainerFunc
 	getPreferredAllocation getPreferredAllocationFunc
+	devType                string
 	state                  serverState
 	stateMutex             sync.Mutex
 }

--- a/pkg/deviceplugin/server_test.go
+++ b/pkg/deviceplugin/server_test.go
@@ -47,11 +47,12 @@ const (
 	resourceName     = namespace + "/testdevicetype"
 )
 
+//nolint: govet
 type kubeletStub struct {
 	sync.Mutex
+	server         *grpc.Server
 	socket         string
 	pluginEndpoint string
-	server         *grpc.Server
 }
 
 func init() {
@@ -248,9 +249,9 @@ func TestAllocate(t *testing.T) {
 	srv := newTestServer()
 
 	tcases := []struct {
-		name              string
 		devices           map[string]DeviceInfo
 		postAllocate      func(*pluginapi.AllocateResponse) error
+		name              string
 		expectedAllocated int
 		expectedErr       bool
 	}{
@@ -374,10 +375,10 @@ func TestAllocate(t *testing.T) {
 
 // Minimal implementation of pluginapi.DevicePlugin_ListAndWatchServer.
 type listAndWatchServerStub struct {
+	cdata       chan []*pluginapi.Device
 	testServer  *server
 	generateErr int
 	sendCounter int
-	cdata       chan []*pluginapi.Device
 }
 
 func (s *listAndWatchServerStub) Send(resp *pluginapi.ListAndWatchResponse) error {
@@ -501,8 +502,8 @@ func TestGetDevicePluginOptions(t *testing.T) {
 
 func TestPreStartContainer(t *testing.T) {
 	tcases := []struct {
-		name              string
 		preStartContainer preStartContainerFunc
+		name              string
 		expectedError     bool
 	}{
 		{
@@ -533,8 +534,8 @@ func TestPreStartContainer(t *testing.T) {
 
 func TestGetPreferredAllocation(t *testing.T) {
 	tcases := []struct {
-		name                   string
 		getPreferredAllocation getPreferredAllocationFunc
+		name                   string
 		expectedError          bool
 	}{
 		{

--- a/pkg/fpga/bitstream/aocx.go
+++ b/pkg/fpga/bitstream/aocx.go
@@ -35,6 +35,10 @@ const (
 
 // A FileAOCX represents an open AOCX file.
 type FileAOCX struct {
+	GBS    *FileGBS
+	closer io.Closer
+	// embed common bitstream interfaces
+	File
 	AutoDiscovery          string
 	AutoDiscoveryXML       string
 	Board                  string
@@ -47,10 +51,6 @@ type FileAOCX struct {
 	QuartusReport          string
 	Target                 string
 	Version                string
-	GBS                    *FileGBS
-	closer                 io.Closer
-	// embed common bitstream interfaces
-	File
 }
 
 // OpenAOCX opens the named file using os.Open and prepares it for use as GBS.

--- a/pkg/fpga/bitstream/gbs.go
+++ b/pkg/fpga/bitstream/gbs.go
@@ -42,18 +42,16 @@ type Header struct {
 
 // FileGBS represents an open GBS file.
 type FileGBS struct {
-	Header
-	Metadata  Metadata
 	Bitstream *Bitstream
 	closer    io.Closer
+	Metadata  Metadata
+	Header
 }
 
 // Metadata represents parsed JSON metadata of GBS file.
 type Metadata struct {
-	Version      int    `json:"version"`
 	PlatformName string `json:"platform-name,omitempty"`
 	AfuImage     struct {
-		MagicNo         int    `json:"magic-no,omitempty"`
 		InterfaceUUID   string `json:"interface-uuid,omitempty"`
 		AfuTopInterface struct {
 			Class       string `json:"class"`
@@ -61,11 +59,10 @@ type Metadata struct {
 				Params struct {
 					Clock string `json:"clock,omitempty"`
 				} `json:"params"`
-				Optional bool   `json:"optional,omitempty"`
 				Class    string `json:"class,omitempty"`
+				Optional bool   `json:"optional,omitempty"`
 			} `json:"module-ports,omitempty"`
 		} `json:"afu-top-interface"`
-		Power               int         `json:"power"`
 		ClockFrequencyHigh  interface{} `json:"clock-frequency-high,omitempty"`
 		ClockFrequencyLow   interface{} `json:"clock-frequency-low,omitempty"`
 		AcceleratorClusters []struct {
@@ -73,12 +70,14 @@ type Metadata struct {
 			Name                string `json:"name"`
 			TotalContexts       int    `json:"total-contexts"`
 		} `json:"accelerator-clusters"`
+		MagicNo int `json:"magic-no,omitempty"`
+		Power   int `json:"power"`
 	} `json:"afu-image"`
+	Version int `json:"version"`
 }
 
 // A Bitstream represents a raw bitsream data (RBF) in the GBS binary.
 type Bitstream struct {
-	Size uint64
 	// Embed ReaderAt for ReadAt method.
 	// Do not embed SectionReader directly
 	// to avoid having Read and Seek.
@@ -89,6 +88,8 @@ type Bitstream struct {
 	sr *io.SectionReader
 	// embed common bitstream interfaces
 	File
+
+	Size uint64
 }
 
 // Open returns a new ReadSeeker reading the bitsream body.

--- a/pkg/fpga/dfl_linux.go
+++ b/pkg/fpga/dfl_linux.go
@@ -68,14 +68,14 @@ func NewDflFME(dev string) (FME, error) {
 // DflPort represent DFL FPGA Port device.
 type DflPort struct {
 	Port
+	PCIDevice *PCIDevice
+	FME       FME
 	DevPath   string
 	SysFsPath string
 	Name      string
-	PCIDevice *PCIDevice
 	Dev       string
 	AFUID     string
 	ID        string
-	FME       FME
 }
 
 // Close closes open device.

--- a/pkg/fpga/intel_fpga_linux.go
+++ b/pkg/fpga/intel_fpga_linux.go
@@ -65,6 +65,7 @@ func NewIntelFpgaFME(dev string) (FME, error) {
 // IntelFpgaPort represent IntelFpga FPGA Port device.
 type IntelFpgaPort struct {
 	Port
+	FME       FME
 	DevPath   string
 	SysFsPath string
 	Name      string
@@ -72,7 +73,6 @@ type IntelFpgaPort struct {
 	Dev       string
 	AFUID     string
 	ID        string
-	FME       FME
 }
 
 // Close closes open device.

--- a/pkg/fpga/pci_linux.go
+++ b/pkg/fpga/pci_linux.go
@@ -38,6 +38,7 @@ var (
 
 // PCIDevice represents most valuable sysfs information about PCI device.
 type PCIDevice struct {
+	PhysFn    *PCIDevice
 	SysFsPath string
 	BDF       string
 	Vendor    string
@@ -48,7 +49,6 @@ type PCIDevice struct {
 	VFs       string
 	TotalVFs  string
 	Driver    string
-	PhysFn    *PCIDevice
 }
 
 // NewPCIDevice returns sysfs entry for specified PCI device.

--- a/pkg/fpgacontroller/fpgacontroller_test.go
+++ b/pkg/fpgacontroller/fpgacontroller_test.go
@@ -43,9 +43,9 @@ func init() {
 
 func TestAcceleratorFunctionReconcile(t *testing.T) {
 	tcases := []struct {
+		getError    error
 		name        string
 		expectedErr bool
-		getError    error
 	}{
 		{
 			name: "empty af",
@@ -94,9 +94,9 @@ func TestAcceleratorFunctionSetupWithManager(t *testing.T) {
 
 func TestFpgaRegionReconcile(t *testing.T) {
 	tcases := []struct {
+		getError    error
 		name        string
 		expectedErr bool
-		getError    error
 	}{
 		{
 			name: "empty region",

--- a/pkg/fpgacontroller/patcher/patcher.go
+++ b/pkg/fpgacontroller/patcher/patcher.go
@@ -70,6 +70,7 @@ var (
 	rfc6901Escaper = strings.NewReplacer("~", "~0", "/", "~1")
 )
 
+//nolint: govet
 type patcher struct {
 	sync.Mutex
 
@@ -217,8 +218,8 @@ func (p *patcher) getPatchOps(containerIdx int, container corev1.Container) ([]s
 			envVars[envvar.Name] = envvar.Value
 		}
 		data := struct {
-			ContainerIdx int
 			EnvVars      map[string]string
+			ContainerIdx int
 		}{
 			ContainerIdx: containerIdx,
 			EnvVars:      envVars,

--- a/pkg/fpgacontroller/patcher/patchermanager_test.go
+++ b/pkg/fpgacontroller/patcher/patchermanager_test.go
@@ -39,8 +39,8 @@ func TestGetPatcher(t *testing.T) {
 	log := ctrl.Log.WithName("test")
 	namespace := "test"
 	tcases := []struct {
-		name string
 		pm   *Manager
+		name string
 	}{
 		{
 			name: "Create new patcher",
@@ -112,10 +112,10 @@ func TestMutate(t *testing.T) {
 	}
 
 	tcases := []struct {
-		name             string
 		ar               admissionv1.AdmissionRequest
-		expectedAllowed  bool
+		name             string
 		expectedPatchOps int
+		expectedAllowed  bool
 	}{
 		{
 			name: "empty admission request",

--- a/pkg/idxd/plugin.go
+++ b/pkg/idxd/plugin.go
@@ -42,14 +42,14 @@ type getDevNodesFunc func(devDir, charDevDir, wqName string) ([]pluginapi.Device
 
 // DevicePlugin defines properties of the idxd device plugin.
 type DevicePlugin struct {
+	scanTicker   *time.Ticker
+	scanDone     chan bool
+	getDevNodes  getDevNodesFunc
 	sysfsDir     string
 	statePattern string
 	devDir       string
 	charDevDir   string
 	sharedDevNum int
-	scanTicker   *time.Ticker
-	scanDone     chan bool
-	getDevNodes  getDevNodesFunc
 }
 
 // NewDevicePlugin creates DevicePlugin.

--- a/pkg/idxd/plugin_test.go
+++ b/pkg/idxd/plugin_test.go
@@ -72,10 +72,10 @@ func (n *fakeNotifier) Notify(deviceTree dpapi.DeviceTree) {
 
 type testCase struct {
 	name           string
-	sysfsDirs      []string
-	sysfsFiles     map[string][]byte
-	sharedDevNum   int
 	expectedResult map[string]int
+	sysfsFiles     map[string][]byte
+	sysfsDirs      []string
+	sharedDevNum   int
 	expectedError  bool
 }
 

--- a/pkg/internal/containers/containers_test.go
+++ b/pkg/internal/containers/containers_test.go
@@ -31,9 +31,9 @@ func TestGetRequestedResources(t *testing.T) {
 	tcases := []struct {
 		name           string
 		namespace      string
+		expectedResult map[string]int64
 		container      corev1.Container
 		expectedErr    bool
-		expectedResult map[string]int64
 	}{
 		{
 			name:      "Normal case",

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -218,10 +218,10 @@ func TestGetDevicesFromVirtual(t *testing.T) {
 
 func TestMergeTopologyHints(t *testing.T) {
 	cases := []struct {
-		name           string
 		inputA         Hints
 		inputB         Hints
 		expectedOutput Hints
+		name           string
 		expectedErr    bool
 	}{
 		{
@@ -277,9 +277,9 @@ func TestNewTopologyHints(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 	cases := []struct {
+		output      Hints
 		name        string
 		input       string
-		output      Hints
 		expectedErr bool
 	}{
 		{
@@ -324,8 +324,8 @@ func TestGetTopologyInfo(t *testing.T) {
 	defer teardown()
 	cases := []struct {
 		name        string
-		input       []string
 		output      *pluginapi.TopologyInfo
+		input       []string
 		expectedErr bool
 	}{
 		{


### PR DESCRIPTION
Add govet-fieldalignment to .golangci.yml
Fix all errors by reordering the fields of structs

Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>